### PR TITLE
Allow download of large files on memory restricted machines, like a VPS

### DIFF
--- a/dload/__init__.py
+++ b/dload/__init__.py
@@ -75,9 +75,11 @@ def save(url, path="", overwrite=False):
 		path = path if path.strip() else c_path+os.path.sep+fn
 		if not overwrite and os.path.isfile(path):
 			return path
-		r = requests.get(url)
-		with open(path, 'wb') as f:
-			f.write(r.content)
+		with requests.get(url, stream=True) as r:
+			r.raise_for_status()
+			with open(path, 'wb') as f:
+				for chunk in r.iter_content(chunk_size=8192):
+					f.write(chunk)
 		return path
 	except:
 		pass


### PR DESCRIPTION
Previously downloading even small files on machines with limited ram would result in a memory error. 
To overcome this the code has been adjusted to stream the file to disk in small chunks.

This has been tested on a VPS with 1gb RAM and works great. It may be worthwhile adding an optional arguement for chunk_size to the save function so that users may get a little more performance. 