### PR TITLE
Add optional error raising flag to save

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ dload.git_clone("https://github.com/x011/dload.git")
         Defaults to script location and url filename
         :param overwrite: bool - (optional)  If True the local file will be overwritten, False will skip the download
         :param chunk_size: int - (optional) streaming chunk size in bytes for writing to disk
+        :param raise_on_error: bool - (optional) If True re-raises download errors instead
+        of returning an empty string
         :return: str - The full path of the downloaded file or an empty string
     
     save_multi(url_list, dir='', max_threads=1, tsleep=0.05)

--- a/dload/__init__.py
+++ b/dload/__init__.py
@@ -90,6 +90,7 @@ def save(
     overwrite: bool = False,
     timeout: int = DEFAULT_TIMEOUT,
     chunk_size: int = 8192,
+    raise_on_error: bool = False,
 ) -> str:
     """
     Download and save a remote file.
@@ -101,6 +102,8 @@ def save(
         will skip the download if the file already exists.
     :param timeout: Optional request timeout in seconds.
     :param chunk_size: Optional size (in bytes) of streaming chunks written to disk.
+    :param raise_on_error: If ``True`` re-raises download errors instead of returning
+        an empty string.
     :return: The full path of the downloaded file or an empty string.
     """
 
@@ -123,6 +126,8 @@ def save(
                         file_handle.write(chunk)
         return destination
     except (OSError, requests.RequestException, ValueError):
+        if raise_on_error:
+            raise
         return ""
 
 


### PR DESCRIPTION
## Summary
- add a raise_on_error flag to dload.save to optionally propagate download errors
- document the new flag in the README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69336792644c8323a72f7df97da893c4)