### PR TITLE
Handle Content-Disposition filenames

### DIFF
--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -1,0 +1,69 @@
+import io
+import os
+import tempfile
+import zipfile
+from unittest import TestCase, mock
+
+import dload
+
+
+class DummyResponse:
+    def __init__(self, content: bytes, headers=None):
+        self._content = content
+        self.headers = headers or {}
+
+    def raise_for_status(self):
+        return None
+
+    def iter_content(self, chunk_size=8192):
+        for index in range(0, len(self._content), chunk_size):
+            yield self._content[index : index + chunk_size]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+
+class SaveTests(TestCase):
+    def test_save_prefers_content_disposition_filename(self):
+        url = "http://example.com/download/file.bin"
+        header_filename = "nested/header-name.txt"
+        expected_name = os.path.basename(header_filename)
+        response = DummyResponse(
+            b"payload", {"content-disposition": f'attachment; filename="{header_filename}"'}
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with mock.patch("dload._get_caller_dir", return_value=tmp_dir), mock.patch(
+                "dload.requests.get", return_value=response
+            ):
+                saved_path = dload.save(url, overwrite=True)
+
+            self.assertEqual(saved_path, os.path.join(tmp_dir, expected_name))
+            with open(saved_path, "rb") as file_handle:
+                self.assertEqual(file_handle.read(), b"payload")
+
+    def test_save_unzip_uses_header_filename_for_destination(self):
+        url = "http://example.com/download/archive.bin"
+        header_filename = "header-archive.zip"
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, "w") as zip_file:
+            zip_file.writestr("file.txt", "content")
+        response = DummyResponse(
+            zip_buffer.getvalue(),
+            {"content-disposition": f'attachment; filename="{header_filename}"'},
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with mock.patch("dload._get_caller_dir", return_value=tmp_dir), mock.patch(
+                "dload.requests.get", return_value=response
+            ):
+                extract_path = dload.save_unzip(url)
+
+            expected_dir = os.path.join(tmp_dir, os.path.splitext(header_filename)[0])
+            self.assertEqual(extract_path, expected_dir)
+            self.assertTrue(os.path.isdir(extract_path))
+            with open(os.path.join(extract_path, "file.txt")) as file_handle:
+                self.assertEqual(file_handle.read(), "content")


### PR DESCRIPTION
## Summary
- prefer Content-Disposition filenames when saving without an explicit path and sanitize unsafe separators
- propagate the chosen filename through save_unzip defaults
- add unit tests covering header-driven filenames that differ from URL paths

## Testing
- python -m unittest discover -s tests


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693368f3705c83239e1923b032f908bd)